### PR TITLE
Add environment-configurable model provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,29 @@
 
 ```bash
 git clone https://github.com/YOUR_ORG/signalzero-node.git
-cd signalzero-node  
+cd signalzero-node
 
-pip install -r requirements.txt  
- 
+pip install -r requirements.txt
+
 ./scripts/launch_server.sh
 ```
+
+---
+
+## ⚙️ Configuration
+
+SignalZero Local Node reads its runtime configuration from environment variables (a `.env` file is supported via `python-dotenv`). The following variables control how language model inference is performed:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `MODEL_PROVIDER` | `local` | Selects the inference backend (`local` or `openai`). |
+| `MODEL_API_URL` | `http://localhost:11434/api/generate` | REST endpoint for the local model server. |
+| `MODEL_NAME` | `llama3:8b-text-q5_K_M` | Name of the local model to invoke. |
+| `MODEL_NUM_PREDICT` | `48` | Token prediction budget for the local model call. |
+| `OPENAI_API_KEY` | _required when using OpenAI_ | API key used to authenticate with OpenAI. |
+| `OPENAI_MODEL` | `gpt-4o-mini` | OpenAI model name to invoke. |
+| `OPENAI_BASE_URL` | unset | Optional override for the OpenAI API base URL. |
+| `OPENAI_TEMPERATURE` | `0.0` | Sampling temperature for OpenAI responses. |
+| `OPENAI_MAX_OUTPUT_TOKENS` | `256` | Maximum tokens returned from OpenAI. |
+
+Set `MODEL_PROVIDER=openai` together with the relevant OpenAI environment variables to call OpenAI-hosted models. Leave the provider at its default `local` value to continue using a self-hosted model endpoint.

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,36 @@
+"""Application configuration utilities."""
+from functools import lru_cache
+from typing import Literal, Optional
+
+from dotenv import load_dotenv
+from pydantic import BaseSettings, Field
+
+load_dotenv()
+
+
+class Settings(BaseSettings):
+    """Settings loaded from environment variables."""
+
+    model_provider: Literal["local", "openai"] = Field(
+        default="local", env="MODEL_PROVIDER"
+    )
+    model_api_url: str = Field(
+        default="http://localhost:11434/api/generate", env="MODEL_API_URL"
+    )
+    model_name: str = Field(default="llama3:8b-text-q5_K_M", env="MODEL_NAME")
+    model_num_predict: int = Field(default=48, env="MODEL_NUM_PREDICT")
+
+    openai_api_key: Optional[str] = Field(default=None, env="OPENAI_API_KEY")
+    openai_model: str = Field(default="gpt-4o-mini", env="OPENAI_MODEL")
+    openai_base_url: Optional[str] = Field(default=None, env="OPENAI_BASE_URL")
+    openai_temperature: float = Field(default=0.0, env="OPENAI_TEMPERATURE")
+    openai_max_output_tokens: int = Field(
+        default=256, env="OPENAI_MAX_OUTPUT_TOKENS"
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return cached application settings."""
+
+    return Settings()

--- a/app/model_call.py
+++ b/app/model_call.py
@@ -1,24 +1,108 @@
-# app/model_call.py
+"""Utilities for invoking the configured language model."""
+from __future__ import annotations
 
-import os
+from typing import Any, Dict, List, Optional
+
 import requests
 
-MODEL_API_URL = os.getenv("MODEL_API_URL", "http://localhost:11434/api/generate")
-MODEL_NAME = os.getenv("MODEL_NAME", "llama3:8b-text-q5_K_M")
+from app.config import get_settings
 
-def model_call(prompt: str) -> str:
-    payload = {
-        "model": MODEL_NAME,
+settings = get_settings()
+_openai_client: Optional[Any] = None
+
+if settings.model_provider == "openai":
+    try:
+        from openai import OpenAI
+    except ImportError as exc:  # pragma: no cover - defensive import guard
+        raise ImportError(
+            "The 'openai' package is required when MODEL_PROVIDER=openai. "
+            "Install it via 'pip install openai'."
+        ) from exc
+else:  # pragma: no cover - defensive assignment for type checkers
+    OpenAI = None  # type: ignore[assignment]
+
+
+def _call_local_model(prompt: str) -> str:
+    """Call the locally hosted model REST API."""
+
+    payload: Dict[str, Any] = {
+        "model": settings.model_name,
         "prompt": prompt,
         "stream": False,
-        "num_predict": 48
+        "num_predict": settings.model_num_predict,
     }
-    print("sending: " + prompt)
-    response = requests.post(MODEL_API_URL, json=payload, timeout=300)
 
+    response = requests.post(settings.model_api_url, json=payload, timeout=300)
     if response.status_code != 200:
-        raise RuntimeError(f"Model API failed: {response.status_code} - {response.text}")
+        raise RuntimeError(
+            f"Model API failed: {response.status_code} - {response.text}"
+        )
 
     data = response.json()
-    print("received:" + data["response"])
     return data["response"]
+
+
+def _normalise_openai_response_content(content: Any) -> str:
+    """Normalise OpenAI response content into a plain string."""
+
+    if content is None:
+        return ""
+
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, list):
+        parts: List[str] = []
+        for item in content:
+            if isinstance(item, dict) and "text" in item:
+                parts.append(str(item["text"]))
+            else:
+                parts.append(str(item))
+        return "".join(parts)
+
+    return str(content)
+
+
+def _call_openai_model(prompt: str) -> str:
+    """Call the OpenAI API using the configured model."""
+
+    if not settings.openai_api_key:
+        raise RuntimeError("OPENAI_API_KEY must be set when MODEL_PROVIDER=openai")
+
+    global _openai_client
+    if _openai_client is None:
+        client_kwargs: Dict[str, Any] = {"api_key": settings.openai_api_key}
+        if settings.openai_base_url:
+            client_kwargs["base_url"] = settings.openai_base_url
+        _openai_client = OpenAI(**client_kwargs)  # type: ignore[call-arg]
+
+    response = _openai_client.chat.completions.create(  # type: ignore[union-attr]
+        model=settings.openai_model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=settings.openai_temperature,
+        max_tokens=settings.openai_max_output_tokens,
+    )
+
+    if not response.choices:
+        raise RuntimeError("OpenAI response contained no choices")
+
+    message = response.choices[0].message
+    return _normalise_openai_response_content(message.content)
+
+
+def model_call(prompt: str) -> str:
+    """Call the configured model provider with the supplied prompt."""
+
+    print("sending: " + prompt)
+
+    if settings.model_provider == "openai":
+        result = _call_openai_model(prompt)
+    elif settings.model_provider == "local":
+        result = _call_local_model(prompt)
+    else:  # pragma: no cover - defensive branch
+        raise ValueError(
+            f"Unsupported MODEL_PROVIDER configured: {settings.model_provider}"
+        )
+
+    print("received:" + result)
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pydantic
 python-dotenv
 httpx
 tiktoken
+openai


### PR DESCRIPTION
## Summary
- introduce a pydantic-based settings module to centralise model configuration sourced from the environment
- extend the model call helper to switch between local and OpenAI providers based on configuration
- document the new configuration options and add the OpenAI SDK dependency

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e584b474748331b29f790599e161ba