### PR TITLE
Add command interpreter and extend symbol store data loading

### DIFF
--- a/app/command_interpreter.py
+++ b/app/command_interpreter.py
@@ -1,0 +1,195 @@
+"""Utilities for parsing and executing structured command blocks emitted by the model."""
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from app import symbol_store
+from app.types import Symbol
+
+
+class CommandInterpreter:
+    """Parse ⟐CMD blocks and dispatch supported actions."""
+
+    _TOKEN = "⟐CMD"
+
+    def __init__(self) -> None:
+        self._handlers: Dict[str, Callable[[Dict[str, Any]], Any]] = {
+            "store_symbol": self._handle_store_symbol,
+            "update_symbol": self._handle_update_symbol,
+            "delete_symbol": self._handle_delete_symbol,
+            "load_symbol": self._handle_load_symbol,
+            "load_kit": self._handle_load_kit,
+            "invoke_agent": self._handle_invoke_agent,
+            # Stubs for unimplemented actions
+            "query_symbols": self._handle_stub,
+            "recurse_graph": self._handle_stub,
+            "emit_feedback": self._handle_stub,
+            "dispatch_task": self._handle_stub,
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def parse_commands(self, text: str) -> List[Dict[str, Any]]:
+        """Extract JSON payloads from ⟐CMD blocks in the provided text."""
+
+        commands: List[Dict[str, Any]] = []
+        search_start = 0
+
+        while True:
+            token_index = text.find(self._TOKEN, search_start)
+            if token_index == -1:
+                break
+
+            brace_start = text.find("{", token_index)
+            if brace_start == -1:
+                break
+
+            json_payload, search_start = self._extract_json_object(text, brace_start)
+            if not json_payload:
+                break
+
+            try:
+                payload = json.loads(json_payload)
+            except json.JSONDecodeError:
+                continue
+
+            if isinstance(payload, dict):
+                commands.append(payload)
+
+        return commands
+
+    def execute_commands(self, commands: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Execute a list of parsed command payloads."""
+
+        results: List[Dict[str, Any]] = []
+        for payload in commands:
+            action = payload.get("action")
+            if not action:
+                results.append({"error": "missing_action", "payload": payload})
+                continue
+
+            handler = self._handlers.get(action, self._handle_unknown)
+            result = handler(payload)
+            results.append({"action": action, "result": result})
+
+        return results
+
+    def run(self, text: str) -> List[Dict[str, Any]]:
+        """Convenience helper to parse and immediately execute commands."""
+
+        commands = self.parse_commands(text)
+        if not commands:
+            return []
+        return self.execute_commands(commands)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _extract_json_object(self, text: str, start_index: int) -> Tuple[Optional[str], int]:
+        depth = 0
+        in_string = False
+        escape = False
+        end_index = start_index
+
+        for index in range(start_index, len(text)):
+            char = text[index]
+            end_index = index
+
+            if in_string:
+                if escape:
+                    escape = False
+                    continue
+                if char == "\\":
+                    escape = True
+                    continue
+                if char == '"':
+                    in_string = False
+                continue
+
+            if char == '"':
+                in_string = True
+                continue
+
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start_index : index + 1], index + 1
+
+        return None, len(text)
+
+    # ------------------------------------------------------------------
+    # Action handlers
+    # ------------------------------------------------------------------
+    def _handle_store_symbol(self, payload: Dict[str, Any]):
+        symbol_data = payload.get("symbol")
+        if not isinstance(symbol_data, dict) or "id" not in symbol_data:
+            return {"status": "error", "reason": "invalid_symbol"}
+
+        symbol = Symbol(**symbol_data)
+        symbol_store.put_symbol(symbol.id, symbol)
+        return symbol
+
+    def _handle_update_symbol(self, payload: Dict[str, Any]):
+        symbol_data = payload.get("symbol")
+        if not isinstance(symbol_data, dict) or "id" not in symbol_data:
+            return {"status": "error", "reason": "invalid_symbol"}
+
+        existing = symbol_store.get_symbol(symbol_data["id"])
+        base = existing.model_dump() if existing else {}
+        base.update(symbol_data)
+        updated = Symbol(**base)
+        symbol_store.put_symbol(updated.id, updated)
+        return updated
+
+    def _handle_delete_symbol(self, payload: Dict[str, Any]):
+        symbol_id = payload.get("symbol_id") or payload.get("id")
+        if not symbol_id:
+            return {"status": "error", "reason": "missing_symbol_id"}
+        removed = symbol_store.delete_symbol(symbol_id)
+        return {"status": "deleted" if removed else "not_found", "id": symbol_id}
+
+    def _handle_load_symbol(self, payload: Dict[str, Any]):
+        ids = payload.get("ids")
+        if ids is None and payload.get("id"):
+            ids = [payload["id"]]
+        if not isinstance(ids, list):
+            return []
+        symbols = [symbol_store.get_symbol(symbol_id) for symbol_id in ids]
+        return [symbol for symbol in symbols if symbol]
+
+    def _handle_load_kit(self, payload: Dict[str, Any]):
+        kit_id = payload.get("kit_id") or payload.get("kit")
+        if not kit_id:
+            return {"status": "error", "reason": "missing_kit_id"}
+        kit = symbol_store.get_kit(kit_id)
+        if not kit:
+            return {"status": "not_found", "kit_id": kit_id}
+        resolved = dict(kit)
+        resolved["triad"] = [sym for sym in kit.get("triad", [])]
+        resolved["exec"] = [sym for sym in kit.get("exec", [])]
+        anchor = kit.get("anchor")
+        if anchor is not None:
+            resolved["anchor"] = anchor
+        return resolved
+
+    def _handle_invoke_agent(self, payload: Dict[str, Any]):
+        agent_id = payload.get("agent_id") or payload.get("id")
+        if not agent_id:
+            return {"status": "error", "reason": "missing_agent_id"}
+        agent = symbol_store.get_agent(agent_id)
+        if not agent:
+            return {"status": "not_found", "agent_id": agent_id}
+        return agent
+
+    def _handle_stub(self, payload: Dict[str, Any]):
+        return {"status": "not_implemented"}
+
+    def _handle_unknown(self, payload: Dict[str, Any]):
+        return {"status": "unknown_action", "payload": payload}
+
+
+__all__ = ["CommandInterpreter"]

--- a/app/inference.py
+++ b/app/inference.py
@@ -2,6 +2,7 @@
 from app.context_manager import ContextManager
 from pathlib import Path
 from app import embedding_index, chat_history
+from app.command_interpreter import CommandInterpreter
 from app.symbol_store import get_symbol
 from app.model_call import model_call
 from app.chat_history import ChatHistory
@@ -43,6 +44,9 @@ def run_query(user_query: str, session_id: str, k: int = 5) -> dict:
     final_reply = None
     accumulated_history = []
 
+    interpreter = CommandInterpreter()
+    executed_commands = []
+
     for phase_id, workflow in WORKFLOW_PHASES:
         ctx = ContextManager()
         ctx.add_system_prompt(load_prompt_phase("system_prompt", "shared"))
@@ -59,6 +63,9 @@ def run_query(user_query: str, session_id: str, k: int = 5) -> dict:
         phase_prompt = ctx.build_prompt(user_query)
         reply_text = model_call(phase_prompt)
 
+        # Execute any emitted commands
+        executed_commands.extend(interpreter.run(reply_text))
+
         # Log output
         accumulated_history.append(("assistant", reply_text))
         final_reply = reply_text
@@ -68,6 +75,7 @@ def run_query(user_query: str, session_id: str, k: int = 5) -> dict:
     return {
         "reply": final_reply,
         "symbols_used": [s.id for s in context_symbols],
-        "history_length": len(chat_turns) + len(accumulated_history)
+        "history_length": len(chat_turns) + len(accumulated_history),
+        "commands": executed_commands,
     }
 

--- a/app/symbol_store.py
+++ b/app/symbol_store.py
@@ -1,15 +1,15 @@
 # app/symbol_store.py
 
-from typing import List, Dict, Optional
-from app.types import Symbol, Facets
-from pydantic import BaseModel
-from app import embedding_index
-import redis
+from typing import Dict, List, Optional
+
 import json
 import os
-import json
 from pathlib import Path
-from app.types import Symbol
+
+import redis
+
+from app import embedding_index
+from app.types import AgentPersona, KitDefinition, Symbol
 
 # --------- Redis Setup ---------
 
@@ -22,8 +22,80 @@ r = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, decode_responses=
 # --------- Redis Symbol Logic ---------
 
 symbol_index: dict[str, Symbol] = {}
+kits_index: Dict[str, KitDefinition] = {}
+agents_index: Dict[str, AgentPersona] = {}
 
-def load_symbol_store_if_empty(path="data/symbol_catalog.min.json"):
+
+def load_agents(path: str = "data/agents.json") -> int:
+    agents_index.clear()
+    file_path = Path(path)
+    if not file_path.exists():
+        return 0
+
+    raw = json.loads(file_path.read_text(encoding="utf-8"))
+    personas = raw.get("personas", []) if isinstance(raw, dict) else []
+
+    count = 0
+    for persona in personas:
+        try:
+            agent = AgentPersona(**persona)
+            agents_index[agent.id] = agent
+            count += 1
+        except Exception as exc:  # pragma: no cover - logging for malformed agents
+            print(f"[SymbolStore] Failed to load agent persona: {persona} — {exc}")
+
+    return count
+
+
+def load_kits(path: str = "data/kits.min.json") -> int:
+    kits_index.clear()
+    file_path = Path(path)
+    if not file_path.exists():
+        return 0
+
+    raw = json.loads(file_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        raise ValueError("Invalid kit catalog format: expected a list of kits.")
+
+    count = 0
+    for item in raw:
+        try:
+            kit = KitDefinition(**item)
+            kits_index[kit.kit] = kit
+            count += 1
+        except Exception as exc:  # pragma: no cover - logging for malformed kits
+            print(f"[SymbolStore] Failed to load kit definition: {item} — {exc}")
+
+    return count
+
+
+def get_agent(agent_id: str) -> Optional[AgentPersona]:
+    return agents_index.get(agent_id)
+
+
+def _resolve_symbol_id(symbol_id: Optional[str]):
+    if not symbol_id:
+        return None
+    symbol = get_symbol(symbol_id)
+    return symbol if symbol else symbol_id
+
+
+def get_kit(kit_id: str) -> Optional[dict]:
+    kit = kits_index.get(kit_id)
+    if not kit:
+        return None
+
+    resolved = kit.model_dump()
+    resolved["triad"] = [
+        sym for sym in (_resolve_symbol_id(sid) for sid in kit.triad) if sym is not None
+    ]
+    resolved["exec"] = [
+        sym for sym in (_resolve_symbol_id(sid) for sid in kit.exec) if sym is not None
+    ]
+    resolved["anchor"] = _resolve_symbol_id(kit.anchor) if kit.anchor else None
+    return resolved
+
+def load_symbol_store_if_empty(path: str = "data/symbol_catalog.min.json"):
 
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
@@ -41,6 +113,8 @@ def load_symbol_store_if_empty(path="data/symbol_catalog.min.json"):
             print(f"[SymbolStore] Failed to load symbol: {s.get('id', '[unknown]')} — {e}")
 
     print(f"[SymbolStore] Loaded {count} symbols into Redis and embedding index.")
+    load_agents()
+    load_kits()
 
 def _key(symbol_id: str) -> str:
     return f"symbol:{symbol_id}"
@@ -53,10 +127,20 @@ def get_symbol(symbol_id: str) -> Optional[Symbol]:
 
 def put_symbol(symbol_id: str, symbol: Symbol) -> str:
     r.set(_key(symbol_id), symbol.model_dump_json())
-    embedding_index.add_symbol(symbol) 
+    embedding_index.add_symbol(symbol)
     if symbol.symbol_domain:
         r.sadd("domains", symbol.symbol_domain)
     return "stored"
+
+
+def delete_symbol(symbol_id: str) -> bool:
+    removed = r.delete(_key(symbol_id))
+    if removed:
+        try:
+            embedding_index.build_index()
+        except Exception as exc:  # pragma: no cover - rebuild failures are logged
+            print(f"[SymbolStore] Failed to rebuild index after delete: {exc}")
+    return bool(removed)
 
 
 def put_symbols_bulk(symbols: List[Symbol]) -> str:

--- a/app/types.py
+++ b/app/types.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 class Facets(BaseModel):
     function: Optional[str] = None
@@ -29,3 +29,21 @@ class Symbol(BaseModel):
     version: Optional[int] = None
     origin: Optional[str] = None
     scope: Optional[List[str]] = None
+
+
+class AgentPersona(BaseModel):
+    class Config:
+        extra = "allow"
+
+    id: str
+    name: Optional[str] = None
+
+
+class KitDefinition(BaseModel):
+    class Config:
+        extra = "allow"
+
+    kit: str
+    triad: List[str] = Field(default_factory=list)
+    anchor: Optional[str] = None
+    exec: List[str] = Field(default_factory=list)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,14 @@
+import os
+import sys
+from pathlib import Path
+
 import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("EMBEDDING_INDEX_BACKEND", "memory")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_command_interpreter.py
+++ b/tests/test_command_interpreter.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+from app import command_interpreter
+from app.command_interpreter import CommandInterpreter
+from app.types import Symbol
+
+
+def test_parse_and_execute(monkeypatch):
+    stored_symbols = {}
+
+    def fake_put(symbol_id, symbol):
+        stored_symbols[symbol_id] = symbol
+
+    def fake_get(symbol_id):
+        return stored_symbols.get(symbol_id)
+
+    def fake_delete(symbol_id):
+        return bool(stored_symbols.pop(symbol_id, None))
+
+    dummy_kit = {"kit": "kit-1", "triad": [Symbol(id="S1")], "exec": [], "anchor": None}
+
+    monkeypatch.setattr(command_interpreter.symbol_store, "put_symbol", fake_put)
+    monkeypatch.setattr(command_interpreter.symbol_store, "get_symbol", fake_get)
+    monkeypatch.setattr(command_interpreter.symbol_store, "delete_symbol", fake_delete)
+    monkeypatch.setattr(command_interpreter.symbol_store, "get_kit", lambda kit_id: dummy_kit)
+    monkeypatch.setattr(
+        command_interpreter.symbol_store,
+        "get_agent",
+        lambda agent_id: SimpleNamespace(id=agent_id, name="Agent"),
+    )
+
+    payload = """
+    Thoughtful reply.
+    ⟐CMD {"action": "store_symbol", "symbol": {"id": "S1", "macro": "macro"}}
+    ⟐CMD {"action": "load_symbol", "ids": ["S1"]}
+    ⟐CMD {"action": "load_kit", "kit": "kit-1"}
+    ⟐CMD {"action": "invoke_agent", "agent_id": "agent-1"}
+    ⟐CMD {"action": "delete_symbol", "id": "S1"}
+    ⟐CMD {"action": "query_symbols", "query": "test"}
+    """
+
+    interpreter = CommandInterpreter()
+    results = interpreter.run(payload)
+
+    assert [item["action"] for item in results] == [
+        "store_symbol",
+        "load_symbol",
+        "load_kit",
+        "invoke_agent",
+        "delete_symbol",
+        "query_symbols",
+    ]
+
+    assert stored_symbols == {}
+    assert isinstance(results[1]["result"][0], Symbol)
+    assert results[2]["result"]["kit"] == "kit-1"
+    assert results[3]["result"].name == "Agent"
+    assert results[5]["result"]["status"] == "not_implemented"


### PR DESCRIPTION
## Summary
- add a command interpreter that parses model-emitted ⟐CMD blocks and dispatches supported symbol, kit, and agent actions
- extend the symbol store to load agent and kit metadata, expose lookup helpers, and support symbol deletion
- integrate the interpreter with the inference workflow and update the test suite, including new fixtures for offline execution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e58d9955548331ae757b311552324c