### PR TITLE
Restore docker-compose defaults for env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Sample environment configuration for docker-compose and local development
+# Copy this file to `.env` to customize the runtime defaults.
+
+MODEL_PROVIDER=local
+MODEL_API_URL=http://ollama:11434/api/generate
+MODEL_NAME=llama3:8b-text-q5_K_M
+OLLAMA_HOST=0.0.0.0
+OLLAMA_PORT=11434

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 .env.local
 .env.*
+!.env.example
 
 # Python artifacts
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install -r requirements.txt
 
 ## ⚙️ Configuration
 
-SignalZero Local Node reads its runtime configuration from environment variables (a `.env` file is supported via `python-dotenv`). The following variables control how language model inference is performed:
+SignalZero Local Node reads its runtime configuration from environment variables (a `.env` file is supported via `python-dotenv`). A checked-in `.env.example` file captures the defaults used by `docker-compose`; copy it to `.env` to customize the stack locally. The following variables control how language model inference is performed:
 
 | Variable | Default | Description |
 | --- | --- | --- |

--- a/app/config.py
+++ b/app/config.py
@@ -34,12 +34,16 @@ class Settings:
             value = os.getenv(name)
             return value if value not in {None, ""} else None
 
+        def _value(name: str, default: str) -> str:
+            value = os.getenv(name)
+            return default if value in {None, ""} else value
+
         data = {
-            "model_provider": os.getenv("MODEL_PROVIDER", cls.model_provider),
-            "model_api_url": os.getenv("MODEL_API_URL", cls.model_api_url),
-            "model_name": os.getenv("MODEL_NAME", cls.model_name),
+            "model_provider": _value("MODEL_PROVIDER", cls.model_provider),
+            "model_api_url": _value("MODEL_API_URL", cls.model_api_url),
+            "model_name": _value("MODEL_NAME", cls.model_name),
             "openai_api_key": _optional("OPENAI_API_KEY"),
-            "openai_model": os.getenv("OPENAI_MODEL", cls.openai_model),
+            "openai_model": _value("OPENAI_MODEL", cls.openai_model),
             "openai_base_url": _optional("OPENAI_BASE_URL"),
         }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - MODEL_API_URL=${MODEL_API_URL}
-      - MODEL_NAME=${MODEL_NAME}
+      - MODEL_API_URL=${MODEL_API_URL:-http://ollama:11434/api/generate}
+      - MODEL_NAME=${MODEL_NAME:-llama3:8b-text-q5_K_M}
       - REDIS_HOST=redis
     depends_on:
       - redis
@@ -29,11 +29,11 @@ services:
     image: ollama/ollama
     restart: always
     ports:
-      - "${OLLAMA_PORT}:11434"
+      - "${OLLAMA_PORT:-11434}:11434"
     volumes:
       - ollama_data:/root/.ollama
     environment:
-      - OLLAMA_HOST=${OLLAMA_HOST}
+      - OLLAMA_HOST=${OLLAMA_HOST:-0.0.0.0}
     healthcheck:
       test: curl -f http://localhost:11434 || exit 1
       interval: 10s


### PR DESCRIPTION
## Summary
- ensure docker-compose provides sane defaults for model and Ollama settings when no .env file is present
- treat empty environment values as fall back to code defaults and add a committed `.env.example`
- document the sample env file so users know how to customize the stack

## Testing
- python scripts/run_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e598da613083319c7e198c5cd88b8a