### PR TITLE
Add CI workflow for linting, security, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'doc/**'
+      - '**/*.md'
+      - 'data/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - 'doc/**'
+      - '**/*.md'
+      - 'data/**'
+
+jobs:
+  lint:
+    name: Lint & Security Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install ruff bandit
+
+      - name: Run ruff
+        run: ruff check .
+
+      - name: Run bandit
+        run: bandit -r . -x tests,data
+
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    needs: lint
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run pytest
+        env:
+          EMBEDDING_INDEX_BACKEND: memory
+        run: pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs linting, security scanning, and tests on pushes to main and pull requests
- skip CI runs for documentation-only and data-only changes via path filters

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e59ac66a2c8331ae3663810ac7338a