### PR TITLE
Secure chat history with encrypted storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ htmlcov/
 chat_sessions/
 dump.rdb
 *.log
+data/chat_encryption.key
 
 # Database snapshots
 *.sqlite

--- a/app/chat_history.py
+++ b/app/chat_history.py
@@ -1,27 +1,44 @@
-import os
 import json
 from pathlib import Path
 from typing import List, Tuple
+
+from app.encryption import EncryptionError, get_cipher
 
 class ChatHistory:
     def __init__(self, storage_dir="chat_sessions"):
         self.storage_dir = Path(storage_dir)
         self.storage_dir.mkdir(exist_ok=True)
+        self._cipher = get_cipher()
 
     def _session_file(self, session_id: str) -> Path:
         return self.storage_dir / f"{session_id}.jsonl"
 
     def append_message(self, session_id: str, role: str, content: str):
         record = {"role": role, "content": content}
+        payload = json.dumps(record).encode("utf-8")
+        encrypted = self._cipher.encrypt(payload)
         with self._session_file(session_id).open("a", encoding="utf-8") as f:
-            f.write(json.dumps(record) + "\n")
+            f.write(encrypted + "\n")
 
     def get_history(self, session_id: str) -> List[Tuple[str, str]]:
         path = self._session_file(session_id)
         if not path.exists():
             return []
+        turns: List[Tuple[str, str]] = []
         with path.open("r", encoding="utf-8") as f:
-            return [(json.loads(line)["role"], json.loads(line)["content"]) for line in f if line.strip()]
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    decrypted = self._cipher.decrypt(line)
+                except EncryptionError as exc:  # pragma: no cover - defensive guard
+                    raise ValueError(
+                        "Failed to decrypt chat history. The encryption key may be invalid."
+                    ) from exc
+                record = json.loads(decrypted.decode("utf-8"))
+                turns.append((record["role"], record["content"]))
+        return turns
 
     def clear_history(self, session_id: str):
         path = self._session_file(session_id)

--- a/app/encryption.py
+++ b/app/encryption.py
@@ -1,0 +1,112 @@
+"""Utilities for encrypting and decrypting chat history."""
+
+from __future__ import annotations
+
+import base64
+import hmac
+import os
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Optional
+
+
+KEY_SIZE = 64  # 32 bytes for keystream derivation, 32 bytes for authentication
+NONCE_SIZE = 16
+TAG_SIZE = 32  # sha256 digest size
+
+_KEY_FILE = Path("data") / "chat_encryption.key"
+_cipher: Optional["ChatCipher"] = None
+
+
+class EncryptionError(Exception):
+    """Raised when encrypted chat history cannot be decrypted."""
+
+
+def _load_or_create_key() -> bytes:
+    """Load the encryption key from disk, generating one if needed."""
+
+    _KEY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if _KEY_FILE.exists():
+        key = _KEY_FILE.read_bytes()
+        if len(key) == KEY_SIZE:
+            return key
+
+    key = os.urandom(KEY_SIZE)
+    _KEY_FILE.write_bytes(key)
+    return key
+
+
+def _derive_keystream(enc_key: bytes, nonce: bytes, length: int) -> bytes:
+    """Derive a keystream using HMAC-SHA256 in counter mode."""
+
+    keystream = bytearray()
+    counter = 0
+    while len(keystream) < length:
+        counter_bytes = counter.to_bytes(8, "big")
+        block = hmac.new(enc_key, nonce + counter_bytes, sha256).digest()
+        keystream.extend(block)
+        counter += 1
+    return bytes(keystream[:length])
+
+
+@dataclass
+class ChatCipher:
+    """Symmetric stream cipher with authentication for chat history."""
+
+    encryption_key: bytes
+    authentication_key: bytes
+
+    @classmethod
+    def from_master_key(cls, key: bytes) -> "ChatCipher":
+        if len(key) != KEY_SIZE:
+            raise ValueError("Chat encryption key must be 64 bytes long.")
+        return cls(key[: KEY_SIZE // 2], key[KEY_SIZE // 2 :])
+
+    def encrypt(self, data: bytes) -> str:
+        nonce = os.urandom(NONCE_SIZE)
+        keystream = _derive_keystream(self.encryption_key, nonce, len(data))
+        ciphertext = bytes(a ^ b for a, b in zip(data, keystream))
+        tag = hmac.new(self.authentication_key, nonce + ciphertext, sha256).digest()
+        return base64.urlsafe_b64encode(nonce + ciphertext + tag).decode("ascii")
+
+    def decrypt(self, token: str) -> bytes:
+        raw = base64.urlsafe_b64decode(token.encode("ascii"))
+        if len(raw) < NONCE_SIZE + TAG_SIZE:
+            raise EncryptionError("Ciphertext is too short to contain authentication data.")
+
+        nonce = raw[:NONCE_SIZE]
+        tag = raw[-TAG_SIZE:]
+        ciphertext = raw[NONCE_SIZE:-TAG_SIZE]
+
+        expected_tag = hmac.new(self.authentication_key, nonce + ciphertext, sha256).digest()
+        if not hmac.compare_digest(tag, expected_tag):
+            raise EncryptionError("Encrypted chat history failed authentication.")
+
+        keystream = _derive_keystream(self.encryption_key, nonce, len(ciphertext))
+        return bytes(a ^ b for a, b in zip(ciphertext, keystream))
+
+
+def initialize_encryption() -> "ChatCipher":
+    """Initialise the global cipher and ensure the key exists on disk."""
+
+    global _cipher
+    key = _load_or_create_key()
+    _cipher = ChatCipher.from_master_key(key)
+    return _cipher
+
+
+def get_cipher() -> "ChatCipher":
+    """Return the global cipher, initialising it on first use."""
+
+    global _cipher
+    if _cipher is None:
+        return initialize_encryption()
+    return _cipher
+
+
+def get_key_path() -> Path:
+    """Return the path where the chat encryption key is stored."""
+
+    return _KEY_FILE
+

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app import routes
 from app.symbol_store import load_symbol_store_if_empty
 from app.embedding_index import build_index
+from app.encryption import initialize_encryption
 
 app = FastAPI(
     title="SignalZero Local Node",
@@ -33,3 +34,5 @@ def read_root():
 async def startup_event():
     load_symbol_store_if_empty()
     build_index()
+    initialize_encryption()
+

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -16,3 +16,19 @@ def test_chat_history_persistence(tmp_path):
 
     history.clear_history("session1")
     assert history.get_history("session1") == []
+
+
+def test_chat_history_encrypted_on_disk(tmp_path):
+    storage = tmp_path / "history"
+    history = ChatHistory(storage_dir=storage)
+
+    history.append_message("secret-session", "user", "super secret message")
+
+    session_file = storage / "secret-session.jsonl"
+    raw_content = session_file.read_text(encoding="utf-8")
+
+    assert "super secret message" not in raw_content
+    assert raw_content.strip().startswith("{") is False
+
+    turns = history.get_history("secret-session")
+    assert turns == [("user", "super secret message")]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,10 +4,11 @@ from app import main
 
 
 def test_root_endpoint(monkeypatch):
-    calls = {"loaded": 0, "built": 0}
+    calls = {"loaded": 0, "built": 0, "encrypted": 0}
 
     monkeypatch.setattr(main, "load_symbol_store_if_empty", lambda: calls.__setitem__("loaded", calls["loaded"] + 1))
     monkeypatch.setattr(main, "build_index", lambda: calls.__setitem__("built", calls["built"] + 1))
+    monkeypatch.setattr(main, "initialize_encryption", lambda: calls.__setitem__("encrypted", calls["encrypted"] + 1))
 
     with TestClient(main.app) as client:
         response = client.get("/")
@@ -16,3 +17,4 @@ def test_root_endpoint(monkeypatch):
     assert response.json() == {"status": "SignalZero Local Node Live"}
     assert calls["loaded"] >= 1
     assert calls["built"] >= 1
+    assert calls["encrypted"] >= 1


### PR DESCRIPTION
## Summary
- add an authenticated symmetric cipher implementation that persists a chat encryption key under data/
- update chat history to encrypt stored messages and decrypt them when loading
- initialize encryption during FastAPI startup and extend tests to cover encrypted persistence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e59b27d4b08331bfcc601aae47e623