### PR TITLE
Add coverage for encryption and logging configuration modules

### DIFF
--- a/app/chat_history.py
+++ b/app/chat_history.py
@@ -8,10 +8,9 @@ from typing import List, Tuple
 
 from app.logging_config import get_logger
 
+from app.encryption import EncryptionError, get_cipher
 
 log = get_logger(__name__)
-
-from app.encryption import EncryptionError, get_cipher
 
 class ChatHistory:
     def __init__(self, storage_dir: str = "chat_sessions"):

--- a/app/main.py
+++ b/app/main.py
@@ -10,9 +10,11 @@ from app.embedding_index import build_index
 from app.logging_config import get_logger
 from app.symbol_store import load_symbol_store_if_empty
 
+from app.encryption import initialize_encryption
+
 log = get_logger(__name__)
 
-from app.encryption import initialize_encryption
+
 
 app = FastAPI(
     title="SignalZero Local Node",

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,58 @@
+import base64
+
+import pytest
+
+from app import encryption
+
+
+@pytest.fixture(autouse=True)
+def reset_cipher(monkeypatch):
+    """Ensure each test starts with a clean encryption module state."""
+
+    monkeypatch.setattr(encryption, "_cipher", None)
+
+
+def _deterministic_bytes(length: int) -> bytes:
+    return bytes((i % 256 for i in range(length)))
+
+
+def test_initialize_encryption_creates_key_file(monkeypatch, tmp_path):
+    key_path = tmp_path / "chat.key"
+    monkeypatch.setattr(encryption, "_KEY_FILE", key_path)
+    monkeypatch.setattr(encryption.os, "urandom", _deterministic_bytes)
+
+    cipher = encryption.initialize_encryption()
+
+    assert key_path.exists(), "encryption key should be created on disk"
+    assert key_path.read_bytes() == _deterministic_bytes(encryption.KEY_SIZE)
+    assert isinstance(cipher, encryption.ChatCipher)
+    assert encryption.get_cipher() is cipher, "initialize_encryption should set the global cipher"
+
+
+def test_chat_cipher_encrypt_decrypt_roundtrip(monkeypatch, tmp_path):
+    key_path = tmp_path / "chat.key"
+    monkeypatch.setattr(encryption, "_KEY_FILE", key_path)
+    key_bytes = _deterministic_bytes(encryption.KEY_SIZE)
+    key_path.write_bytes(key_bytes)
+
+    cipher = encryption.initialize_encryption()
+
+    nonce = b"\xAA" * encryption.NONCE_SIZE
+    monkeypatch.setattr(encryption.os, "urandom", lambda size: nonce)
+
+    message = b"secret history"
+    token = cipher.encrypt(message)
+
+    assert cipher.decrypt(token) == message
+
+    decoded = bytearray(base64.urlsafe_b64decode(token.encode("ascii")))
+    decoded[-1] ^= 0x01
+    tampered_token = base64.urlsafe_b64encode(bytes(decoded)).decode("ascii")
+
+    with pytest.raises(encryption.EncryptionError):
+        cipher.decrypt(tampered_token)
+
+
+def test_chat_cipher_key_length_validation():
+    with pytest.raises(ValueError):
+        encryption.ChatCipher.from_master_key(b"short")

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from app import logging_config
+
+
+def test_configure_logging_idempotent(monkeypatch, tmp_path):
+    monkeypatch.setattr(logging_config, "_CONFIGURED", False)
+    monkeypatch.setattr(logging_config, "_ensure_log_directory", lambda: tmp_path)
+
+    dict_configs = []
+
+    def fake_dict_config(config):
+        dict_configs.append(config)
+
+    monkeypatch.setattr(logging_config.logging.config, "dictConfig", fake_dict_config)
+
+    struct_calls = []
+
+    def fake_structlog_configure(**kwargs):
+        struct_calls.append(kwargs)
+
+    monkeypatch.setattr(logging_config.structlog, "configure", fake_structlog_configure)
+    captured_names = []
+    monkeypatch.setattr(
+        logging_config.structlog, "get_logger", lambda name: captured_names.append(name) or {"name": name}
+    )
+
+    logger_one = logging_config.get_logger("alpha")
+    logger_two = logging_config.get_logger("beta")
+
+    assert logger_one == {"name": "alpha"}
+    assert logger_two == {"name": "beta"}
+    assert len(dict_configs) == 1
+    assert dict_configs[0]["handlers"]["file"]["filename"] == str(tmp_path / "app.log")
+    assert len(struct_calls) == 1
+    assert captured_names == ["alpha", "beta"]
+    assert logging_config._CONFIGURED is True
+
+
+def test_rotate_on_start_moves_existing_log(monkeypatch, tmp_path):
+    log_file = tmp_path / "app.log"
+    log_file.write_text("prior contents")
+
+    fixed_now = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    monkeypatch.setattr(logging_config, "datetime", SimpleNamespace(now=lambda tz=None: fixed_now))
+
+    logging_config._rotate_on_start(log_file)
+
+    assert not log_file.exists()
+    rotated_files = list(tmp_path.glob("app.*.log"))
+    assert len(rotated_files) == 1
+    assert rotated_files[0].read_text() == "prior contents"


### PR DESCRIPTION
## Summary
- add focused unit tests that exercise the encryption key lifecycle and cipher error handling
- cover logging configuration idempotence and rotation behavior to guard against regressions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5a5e5631c833189b87caa0210b2dc